### PR TITLE
Fix deadlock in case of seeding for 0 seconds

### DIFF
--- a/src/main/java/com/turn/ttorrent/client/Client.java
+++ b/src/main/java/com/turn/ttorrent/client/Client.java
@@ -912,18 +912,14 @@ public class Client extends Observable implements Runnable,
 		logger.info("Download of {} pieces completed.",
 			this.torrent.getPieceCount());
 
-		if (this.seed == 0) {
-			logger.info("No seeding requested, stopping client...");
-			this.stop();
-			return;
-		}
-
 		this.setState(ClientState.SEEDING);
 		if (this.seed < 0) {
 			logger.info("Seeding indefinetely...");
 			return;
 		}
 
+		// In case seeding for 0 seconds we still need to schedule the task in
+		// order to call stop() from different thread to avoid deadlock
 		logger.info("Seeding for {} seconds...", this.seed);
 		Timer timer = new Timer();
 		timer.schedule(new ClientShutdown(this, timer), this.seed*1000);

--- a/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
+++ b/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
@@ -113,6 +113,7 @@ class PeerExchange {
 		this.out = new OutgoingThread();
 		this.out.setName("bt-peer(" +
 			this.peer.getShortHexPeerId() + ")-send");
+		this.out.setDaemon(true);
 
 		// Automatically start the exchange activity loops
 		this.stop = false;


### PR DESCRIPTION
Hi, 

Thank you for great library!
But I've come at some deadlock, hopefully this commit completely fixes it.

**How to reproduce?**

From the top-level directory run preparation commands

``` bash
mkdir -p t
rm t/*
mkdir -p client-2
rm client-2/*
echo "Some data" > t/file.txt
bin/torrent -t t/file.txt.torrent -c -a http://0.0.0.0:6969/announce t/file.txt
```

Then in different terminals run tracker and client

```
bin/tracker t
```

```
bin/client -o t t/file.txt.torrent
```

And at last, modify client script to make it share for 0 seconds and run it

```
bin/client -o client-2 t/file.txt.torrent 
```

With great probability it will stuck in deadlock.

**How the fix helps?**
1. We need to join the client thread from thread different than recv thread (it takes too many locks and client thread can't finish)
2. The OutgoingThread should be specified as Daemon thread (otherwise we need to wait up to 2 minutes until it finished polling).

**P.S.** I also added command line option `-s (--seed)` to specify the time to seed after downloading. This helped  me to test that case and brings more flexibility to program.
