### PR TITLE
Fix read when message size wasn't read in one step

### DIFF
--- a/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
+++ b/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
@@ -210,21 +210,18 @@ class PeerExchange {
 					buffer.rewind();
 					buffer.limit(PeerMessage.MESSAGE_LENGTH_FIELD_SIZE);
 
-					if (channel.read(buffer) < 0) {
-						throw new EOFException(
-							"Reached end-of-stream while reading size header");
-					}
-
 					// Keep reading bytes until the length field has been read
 					// entirely.
-					if (buffer.hasRemaining()) {
+					while (!stop && buffer.hasRemaining()) {
+						if (channel.read(buffer) < 0) {
+							throw new EOFException(
+								"Reached end-of-stream while reading size header");
+						}
 						try {
 							Thread.sleep(1);
 						} catch (InterruptedException ie) {
 							// Ignore and move along.
 						}
-
-						continue;
 					}
 
 					int pstrlen = buffer.getInt(0);


### PR DESCRIPTION
This bug is not that easy to reproduce, but the mental experiment can help.

Suppose that you received only 3 (out of 4) bytes for message size.
Then you would go for the next iteration, call `buffer.rewind()`,that will throw away all the read bytes and starts reading message size from the new position. (and the new message size read will obviously be incorrect).

This patch hopefully fixes this behavior.
