### PR TITLE
Use maven-shade-plugin to produce executable jar

### DIFF
--- a/bin/client
+++ b/bin/client
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 base=$(dirname $(readlink -f $0))
-exec java -jar $(find ${base}/../build -name "ttorrent-*.jar" | tail -n 1) $*
+exec java -jar $(find ${base}/../build -name "ttorrent-*-shaded.jar" | tail -n 1) $*

--- a/bin/torrent
+++ b/bin/torrent
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 base=$(dirname $(readlink -f $0))
-exec java -cp $(find ${base}/../build -name "ttorrent-*.jar" | tail -n 1) com.turn.ttorrent.common.Torrent $*
+exec java -cp $(find ${base}/../build -name "ttorrent-*-shaded.jar" | tail -n 1) com.turn.ttorrent.common.Torrent $*

--- a/bin/tracker
+++ b/bin/tracker
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 base=$(dirname $(readlink -f $0))
-exec java -cp $(find ${base}/../build -name "ttorrent-*.jar" | tail -n 1) com.turn.ttorrent.tracker.Tracker $*
+exec java -cp $(find ${base}/../build -name "ttorrent-*-shaded.jar" | tail -n 1) com.turn.ttorrent.tracker.Tracker $*

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,11 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.4</version>
 				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+						</manifest>
+					</archive>
 					<includes>
 						<include>**</include>
 					</includes>
@@ -144,28 +149,24 @@
 			</plugin>
 
 			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-					<appendAssemblyId>false</appendAssemblyId>
-					<archive>
-						<manifest>
-							<addClasspath>false</addClasspath>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-							<mainClass>com.turn.ttorrent.client.Client</mainClass>
-						</manifest>
-					</archive>
-				</configuration>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>2.1</version>
 				<executions>
 					<execution>
-						<id>make-my-jar-with-dependencies</id>
 						<phase>package</phase>
 						<goals>
-							<!--change assembly to single if you don't want include dependencies in jar-->
-							<goal>assembly</goal>
+							<goal>shade</goal>
 						</goals>
+						<configuration>
+							<outputFile>${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar</outputFile>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Main-Class>com.turn.ttorrent.client.Client</Main-Class>
+									</manifestEntries>
+								</transformer>
+							</transformers>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
Switch from using the maven-assembly-plugin to the recommended maven-shade-plugin for creating the executable (i.e. dependencies included) jar.  The build now produces both

1) ttorrent-VERSION.jar without dependencies suitable for deployment to maven repositories and subsequent use as a library dependency in other maven projects.

2) ttorrent-VERSION-shaded.jar which includes all dependencies and a Main-Class manifest attribute allowing it to be executed at the command-line.  This jar is built but not "attached" to the project at runtime, which means it won't be included in the set of artifacts uploaded by the "install" or "deploy" targets.
