### PR TITLE
Update pom for compatibility with the maven-release-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<url>http://turn.github.com/ttorrent/</url>
 	<groupId>com.turn</groupId>
 	<artifactId>ttorrent</artifactId>
-	<version>1.2</version>
+	<version>1.3-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<organization>
@@ -27,7 +27,9 @@
 
 	<scm>
 		<connection>scm:git:git://github.com/turn/ttorrent.git</connection>
+		<developerConnection>scm:git:ssh://git@github.com/turn/ttorrent.git</developerConnection>
 		<url>http://github.com/turn/ttorrent</url>
+		<tag>HEAD</tag>
 	</scm>
 
 	<licenses>


### PR DESCRIPTION
These changes, combined with https://github.com/turn/ttorrent/pull/54, make the project compatible with the maven-release-plugin workflow.
