### PR TITLE
Fixes turn/ttorrent#42

### DIFF
--- a/src/main/java/com/turn/ttorrent/common/protocol/http/HTTPAnnounceResponseMessage.java
+++ b/src/main/java/com/turn/ttorrent/common/protocol/http/HTTPAnnounceResponseMessage.java
@@ -87,6 +87,11 @@ public class HTTPAnnounceResponseMessage extends HTTPTrackerMessage
 
 		Map<String, BEValue> params = decoded.getMap();
 
+		if (params.get("interval") == null) {
+			throw new MessageValidationException(
+				"Tracker message missing mandatory field 'interval'!");
+		}
+
 		try {
 			List<Peer> peers;
 
@@ -102,8 +107,8 @@ public class HTTPAnnounceResponseMessage extends HTTPTrackerMessage
 
 			return new HTTPAnnounceResponseMessage(data,
 				params.get("interval").getInt(),
-				params.get("complete").getInt(),
-				params.get("incomplete").getInt(),
+				params.get("complete") != null ? params.get("complete").getInt() : 0,
+				params.get("incomplete") != null ? params.get("incomplete").getInt() : 0,
 				peers);
 		} catch (InvalidBEncodingException ibee) {
 			throw new MessageValidationException("Invalid response " +


### PR DESCRIPTION
Handle optionality of 'complete' and 'incomplete fields', and throw MessageValidationException instead of NullPointerException if the 'interval' field is missing.
