### PR TITLE
Use commons-codec for hex and digest encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.8</version>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>2.4</version>

--- a/src/main/java/com/turn/ttorrent/client/Piece.java
+++ b/src/main/java/com/turn/ttorrent/client/Piece.java
@@ -21,7 +21,6 @@ import com.turn.ttorrent.client.storage.TorrentByteStorage;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 
@@ -159,16 +158,10 @@ public class Piece implements Comparable<Piece> {
 		logger.trace("Validating {}...", this);
 		this.valid = false;
 
-		try {
-			// TODO: remove cast to int when large ByteBuffer support is
-			// implemented in Java.
-			ByteBuffer buffer = this._read(0, this.length);
-			byte[] data = new byte[(int)this.length];
-			buffer.get(data);
-			this.valid = Arrays.equals(Torrent.hash(data), this.hash);
-		} catch (NoSuchAlgorithmException nsae) {
-			logger.error("{}", nsae);
-		}
+		ByteBuffer buffer = this._read(0, this.length);
+		byte[] data = new byte[(int)this.length];
+		buffer.get(data);
+		this.valid = Arrays.equals(Torrent.hash(data), this.hash);
 
 		return this.isValid();
 	}

--- a/src/main/java/com/turn/ttorrent/client/SharedTorrent.java
+++ b/src/main/java/com/turn/ttorrent/client/SharedTorrent.java
@@ -29,7 +29,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Collections;
@@ -117,10 +116,9 @@ public class SharedTorrent extends Torrent implements PeerActivityListener {
 	 * @throws FileNotFoundException If the torrent file location or
 	 * destination directory does not exist and can't be created.
 	 * @throws IOException If the torrent file cannot be read or decoded.
-	 * @throws NoSuchAlgorithmException
 	 */
 	public SharedTorrent(Torrent torrent, File destDir)
-		throws FileNotFoundException, IOException, NoSuchAlgorithmException {
+		throws FileNotFoundException, IOException {
 		this(torrent, destDir, false);
 	}
 
@@ -140,10 +138,9 @@ public class SharedTorrent extends Torrent implements PeerActivityListener {
 	 * @throws FileNotFoundException If the torrent file location or
 	 * destination directory does not exist and can't be created.
 	 * @throws IOException If the torrent file cannot be read or decoded.
-	 * @throws NoSuchAlgorithmException
 	 */
 	public SharedTorrent(Torrent torrent, File destDir, boolean seeder)
-		throws FileNotFoundException, IOException, NoSuchAlgorithmException {
+		throws FileNotFoundException, IOException {
 		this(torrent.getEncoded(), destDir, seeder);
 	}
 
@@ -158,7 +155,7 @@ public class SharedTorrent extends Torrent implements PeerActivityListener {
 	 * @throws IOException If the torrent file cannot be read or decoded.
 	 */
 	public SharedTorrent(byte[] torrent, File destDir)
-		throws FileNotFoundException, IOException, NoSuchAlgorithmException {
+		throws FileNotFoundException, IOException {
 		this(torrent, destDir, false);
 	}
 
@@ -172,10 +169,9 @@ public class SharedTorrent extends Torrent implements PeerActivityListener {
 	 * @throws FileNotFoundException If the torrent file location or
 	 * destination directory does not exist and can't be created.
 	 * @throws IOException If the torrent file cannot be read or decoded.
-	 * @throws NoSuchAlgorithmException
 	 */
 	public SharedTorrent(byte[] torrent, File parent, boolean seeder)
-		throws FileNotFoundException, IOException, NoSuchAlgorithmException {
+		throws FileNotFoundException, IOException {
 		super(torrent, seeder);
 
 		if (parent == null || !parent.isDirectory()) {
@@ -236,10 +232,9 @@ public class SharedTorrent extends Torrent implements PeerActivityListener {
 	 * meta-info from.
 	 * @param parent The parent directory or location of the torrent files.
 	 * @throws IOException When the torrent file cannot be read or decoded.
-	 * @throws NoSuchAlgorithmException
 	 */
 	public static SharedTorrent fromFile(File source, File parent)
-		throws IOException, NoSuchAlgorithmException {
+		throws IOException {
 		byte[] data = FileUtils.readFileToByteArray(source);
 		return new SharedTorrent(data, parent);
 	}

--- a/src/main/java/com/turn/ttorrent/tracker/TrackedTorrent.java
+++ b/src/main/java/com/turn/ttorrent/tracker/TrackedTorrent.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -77,11 +76,8 @@ public class TrackedTorrent extends Torrent {
 	 * @param torrent The meta-info byte data.
 	 * @throws IOException When the info dictionary can't be
 	 * encoded and hashed back to create the torrent's SHA-1 hash.
-	 * @throws NoSuchAlgorithmException If the SHA-1 algorithm is not
-	 * available.
 	 */
-	public TrackedTorrent(byte[] torrent)
-		throws IOException, NoSuchAlgorithmException {
+	public TrackedTorrent(byte[] torrent) throws IOException {
 		super(torrent, false);
 
 		this.peers = new ConcurrentHashMap<String, TrackedPeer>();
@@ -89,8 +85,7 @@ public class TrackedTorrent extends Torrent {
 		this.announceInterval = TrackedTorrent.DEFAULT_ANNOUNCE_INTERVAL_SECONDS;
 	}
 
-	public TrackedTorrent(Torrent torrent)
-		throws IOException, NoSuchAlgorithmException {
+	public TrackedTorrent(Torrent torrent) throws IOException {
 		this(torrent.getEncoded());
 	}
 
@@ -293,10 +288,8 @@ public class TrackedTorrent extends Torrent {
 	 * @param torrent The abstract {@link File} object representing the
 	 * <tt>.torrent</tt> file to load.
 	 * @throws IOException When the torrent file cannot be read.
-	 * @throws NoSuchAlgorithmException
 	 */
-	public static TrackedTorrent load(File torrent) throws IOException,
-		NoSuchAlgorithmException {
+	public static TrackedTorrent load(File torrent) throws IOException {
 		byte[] data = FileUtils.readFileToByteArray(torrent);
 		return new TrackedTorrent(data);
 	}


### PR DESCRIPTION
As per the commons-code homepage, it was designed to do two things: 1) Provide canonical implementations of base-XX encoding (including hex), and 2) Provide convenience methods for working with digests.  Both of which ttorrent can take advantage of.  Specifically:

1) Torrent#byteArrayToHexString performance using the commons-codec implementation is improved as much or more than 100x.

2) Use of commons-codec digest utility methods allows us to clean up and simplify numerous method signatures by eliminating NoSuchAlgorithmException declarations.  These declarations make refactoring more cumbersome, and provide no advantage even on systems where SHA-1 digests aren't available (as the ttorrent codebase is equally inoperative either way in that case).
