### PR TITLE
Fix Piece compareTo ordering

### DIFF
--- a/src/main/java/com/turn/ttorrent/client/Piece.java
+++ b/src/main/java/com/turn/ttorrent/client/Piece.java
@@ -276,11 +276,11 @@ public class Piece implements Comparable<Piece> {
 	 * @param other The piece to compare with, should not be <em>null</em>.
 	 */
 	public int compareTo(Piece other) {
-		int retval = Integer.compare(this.seen, other.seen);
-		if (retval == 0) {
-			retval = Integer.compare(this.index, other.index);
+		if (this.seen != other.seen) {
+			return this.seen < other.seen ? -1 : 1;
 		}
-		return retval;
+		return this.index == other.index ? 0 :
+			(this.index < other.index ? -1 : 1);
 	}
 
 	/**


### PR DESCRIPTION
This is a fix for the case of Piece.compareTo returning inconsistent ordering.

Specifically if you have (pseudocode):

  Piece p1, p2;
  p1.seen = p2.seen = arbitraryInteger;

Then you'd would see with the old code:

  p1.compareTo(p2) == p2.compareTo(p1) == 1

This is wrong and will give headaches to sorting algorithms.  One of those should be -1, they should only be equal when they both return 0.  The new code provides consistent ordering by seen then index.
