### PR TITLE
Change FileCollectionStorage to not write 0 bytes to the next file at the end

### DIFF
--- a/src/main/java/com/turn/ttorrent/client/storage/FileCollectionStorage.java
+++ b/src/main/java/com/turn/ttorrent/client/storage/FileCollectionStorage.java
@@ -182,7 +182,7 @@ public class FileCollectionStorage implements TorrentByteStorage {
 		long bytes = 0;
 
 		for (FileStorage file : this.files) {
-			if (file.offset() > offset + length) {
+			if (file.offset() >= offset + length) {
 				break;
 			}
 

--- a/test/main/java/com/turn/ttorrent/client/storage/FileCollectionStorageTest.java
+++ b/test/main/java/com/turn/ttorrent/client/storage/FileCollectionStorageTest.java
@@ -1,0 +1,61 @@
+package com.turn.ttorrent.client.storage;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * User: loyd
+ * Date: 11/24/13
+ */
+public class FileCollectionStorageTest {
+    @Test
+    public void testSelect() throws Exception {
+        final File file1 = File.createTempFile("testng", "fcst");
+        file1.deleteOnExit();
+        final File file2 = File.createTempFile("testng", "fcst");
+        file2.deleteOnExit();
+
+        final List<FileStorage> files = new ArrayList<FileStorage>();
+        files.add(new FileStorage(file1, 0, 2));
+        files.add(new FileStorage(file2, 2, 2));
+        final FileCollectionStorage storage = new FileCollectionStorage(files, 4);
+        // since all of these files already exist, we are considered finished
+        assertTrue(storage.isFinished());
+
+        // write to first file works
+        write(new byte[]{1, 2}, 0, storage);
+        check(new byte[]{1, 2}, file1);
+
+        // write to second file works
+        write(new byte[]{5, 6}, 2, storage);
+        check(new byte[]{5, 6}, file2);
+
+        // write to two files works
+        write(new byte[]{8,9,10,11}, 0, storage);
+        check(new byte[]{8,9}, file1);
+        check(new byte[]{10,11}, file2);
+
+        // make sure partial write into next file works
+        write(new byte[]{100,101,102}, 0, storage);
+        check(new byte[]{102,11}, file2);
+    }
+
+    private void write(byte[] bytes, int offset, FileCollectionStorage storage) throws IOException {
+        storage.write(ByteBuffer.wrap(bytes), offset);
+        storage.finish();
+    }
+    private void check(byte[] bytes, File f) throws IOException {
+        final byte[] temp = new byte[bytes.length];
+        assertEquals(new FileInputStream(f).read(temp), temp.length);
+        assertEquals(temp, bytes);
+    }
+}


### PR DESCRIPTION
Currently at the end of writing to a file it is likely that the offset+length will be equal to the next file offset. Usually while selecting files once we get to a file that is greater than our current offset+length we break out of the loop. I would consider the next file that has offset+length equal to the offset to be outside of the range that we should be writing to, so we should also break out for equals to.
