### PR TITLE
fix order of fields in the 'send announce' packets going to udp trackers

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/common/protocol/udp/UDPAnnounceRequestMessage.java
+++ b/core/src/main/java/com/turn/ttorrent/common/protocol/udp/UDPAnnounceRequestMessage.java
@@ -229,8 +229,8 @@ public class UDPAnnounceRequestMessage
 		data.put(infoHash);
 		data.put(peerId);
 		data.putLong(downloaded);
-		data.putLong(uploaded);
 		data.putLong(left);
+		data.putLong(uploaded);
 		data.putInt(event.getId());
 		data.put(ip.getAddress());
 		data.putInt(key);


### PR DESCRIPTION
when sending announce packets to a udp tracker, the correct order is: downloaded, left, uploaded
(see http://xbtt.sourceforge.net/udp_tracker_protocol.html)
and not downloaded, uploaded, left.