### PR TITLE
Change the ClientState messages to logger.debug

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/Client.java
+++ b/core/src/main/java/com/turn/ttorrent/client/Client.java
@@ -448,7 +448,7 @@ public class Client extends Observable implements Runnable,
 			ul += peer.getULRate().get();
 		}
 
-		logger.info("{} {}/{} pieces ({}%) [{}/{}] with {}/{} peers at {}/{} kB/s.",
+		logger.debug("{} {}/{} pieces ({}%) [{}/{}] with {}/{} peers at {}/{} kB/s.",
 			new Object[] {
 				this.getState().name(),
 				this.torrent.getCompletedPieces().cardinality(),


### PR DESCRIPTION
They're really cluttering up the output of my program, and considering that they occur every few seconds, it makes them a better candidate for log.debug rather than log.info.
