### PR TITLE
Fix connection http

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/announce/HTTPTrackerClient.java
+++ b/core/src/main/java/com/turn/ttorrent/client/announce/HTTPTrackerClient.java
@@ -44,6 +44,8 @@ public class HTTPTrackerClient extends TrackerClient {
 
 	protected static final Logger logger =
 		LoggerFactory.getLogger(HTTPTrackerClient.class);
+	private final static String USER_AGENT = "Mozilla/5.0";
+	private final static String USER_AGENT_HEADER = "User-Agent";
 
 	/**
 	 * Create a new HTTP announcer for the given torrent.
@@ -105,6 +107,7 @@ public class HTTPTrackerClient extends TrackerClient {
 		InputStream in = null;
 		try {
 			conn = (HttpURLConnection)target.openConnection();
+			conn.setRequestProperty(USER_AGENT_HEADER,USER_AGENT);
 			in = conn.getInputStream();
 		} catch (IOException ioe) {
 			if (conn != null) {

--- a/core/src/main/java/com/turn/ttorrent/client/announce/HTTPTrackerClient.java
+++ b/core/src/main/java/com/turn/ttorrent/client/announce/HTTPTrackerClient.java
@@ -44,8 +44,8 @@ public class HTTPTrackerClient extends TrackerClient {
 
 	protected static final Logger logger =
 		LoggerFactory.getLogger(HTTPTrackerClient.class);
-	private final static String USER_AGENT = "Mozilla/5.0";
-	private final static String USER_AGENT_HEADER = "User-Agent";
+	private static final String USER_AGENT = "Mozilla/5.0";
+	private static final String USER_AGENT_HEADER = "User-Agent";
 
 	/**
 	 * Create a new HTTP announcer for the given torrent.


### PR DESCRIPTION

At the beginning
```
2015-09-26 00:00:30 WARN  Announce:226 - Error reading tracker response!
2015-09-26 00:00:31 INFO  Client:451 - SHARING 0/1410 pieces (0,00%) [0/0] with 0/0 peers at 0,00/0,00 kB/s.
2015-09-26 00:00:34 INFO  Client:451 - SHARING 0/1410 pieces (0,00%) [0/0] with 0/0 peers at 0,00/0,00 kB/s.
2015-09-26 00:00:35 INFO  HTTPTrackerClient:80 - Announcing STARTED to tracker with 0U/0D/369412096L bytes...
2015-09-26 00:00:35 WARN  Announce:226 - Error reading tracker response!
```

After investigation,
I found an error in response for Http request (403) 
But with adding user agent in header of request. Http request can go through tracker's protection.

By the way, the protection is cloudflare. 

