### PR TITLE
Fixed bitfield payload in bitfield message

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
+++ b/core/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
@@ -131,7 +131,7 @@ class PeerExchange {
 		// If we have pieces, start by sending a BITFIELD message to the peer.
 		BitSet pieces = this.torrent.getCompletedPieces();
 		if (pieces.cardinality() > 0) {
-			this.send(PeerMessage.BitfieldMessage.craft(pieces));
+			this.send(PeerMessage.BitfieldMessage.craft(pieces, torrent.getPieceCount()));
 		}
 	}
 

--- a/core/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
+++ b/core/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
@@ -120,10 +120,7 @@ class PeerExchange {
 			this.peer.getShortHexPeerId() + ")-send");
 		this.out.setDaemon(true);
 
-		// Automatically start the exchange activity loops
 		this.stop = false;
-		this.in.start();
-		this.out.start();
 
 		logger.debug("Started peer exchange with {} for {}.",
 			this.peer, this.torrent);
@@ -135,6 +132,7 @@ class PeerExchange {
 		}
 	}
 
+	
 	/**
 	 * Register a new message listener to receive messages.
 	 *
@@ -172,13 +170,25 @@ class PeerExchange {
 	}
 
 	/**
-	 * Close and stop the peer exchange.
+	 * Start the peer exchange.
+	 *
+	 * <p>
+	 * Starts both incoming and outgoing thread.
+	 * </p>
+	 */
+	public void start() {
+		this.in.start();
+		this.out.start();
+	}
+	
+	/**
+	 * Stop the peer exchange.
 	 *
 	 * <p>
 	 * Closes the socket channel and stops both incoming and outgoing threads.
 	 * </p>
 	 */
-	public void close() {
+	public void stop() {
 		this.stop = true;
 
 		if (this.channel.isConnected()) {

--- a/core/src/main/java/com/turn/ttorrent/client/peer/SharingPeer.java
+++ b/core/src/main/java/com/turn/ttorrent/client/peer/SharingPeer.java
@@ -270,6 +270,7 @@ public class SharingPeer extends Peer implements MessageListener {
 
 		this.exchange = new PeerExchange(this, this.torrent, channel);
 		this.exchange.register(this);
+		this.exchange.start();
 
 		this.download = new Rate();
 		this.download.reset();
@@ -308,7 +309,7 @@ public class SharingPeer extends Peer implements MessageListener {
 
 		synchronized (this.exchangeLock) {
 			if (this.exchange != null) {
-				this.exchange.close();
+				this.exchange.stop();
 				this.exchange = null;
 			}
 		}

--- a/core/src/test/java/com/turn/ttorrent/common/protocol/PeerMessageTest.java
+++ b/core/src/test/java/com/turn/ttorrent/common/protocol/PeerMessageTest.java
@@ -1,0 +1,146 @@
+package com.turn.ttorrent.common;
+
+import com.turn.ttorrent.common.protocol.PeerMessage;
+
+import org.testng.annotations.Test;
+
+import java.nio.ByteBuffer;
+import java.util.BitSet;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertTrue;
+
+
+public class PeerMessageTest {
+
+    @Test
+    public void testCraftBitfieldMessage()  {
+        // See https://wiki.theory.org/BitTorrentSpecification#bitfield
+
+        // Create message with 744 (= 93 * 8) pieces
+        BitSet availablePieces = new BitSet();
+        availablePieces.set(0);
+        availablePieces.set(700);
+        availablePieces.set(743); // last piece
+        availablePieces.set(744); // out of range - should be ignored
+        PeerMessage.BitfieldMessage msg = PeerMessage.BitfieldMessage.craft(availablePieces, 744);
+
+        // Check bitfield
+        assertEquals(3, msg.getBitfield().cardinality());
+        assertEquals(true, msg.getBitfield().get(0));
+        assertEquals(true, msg.getBitfield().get(700));
+        assertEquals(true, msg.getBitfield().get(743));
+
+        // Check raw data - bitfield: <len=0001+X><id=5><bitfield>
+        ByteBuffer buffer = msg.getData();
+
+        // total size
+        assertEquals(4 + 1 + 93, buffer.remaining());
+
+        // len
+        assertEquals(0, buffer.get(0));
+        assertEquals(0, buffer.get(1));
+        assertEquals(0, buffer.get(2));
+        assertEquals(1 + 93, (int)buffer.get(3));
+
+        // id
+        assertEquals(5, buffer.get(4));
+
+        // bitfield
+        buffer.position(5);
+        ByteBuffer bitfieldBuffer = buffer.slice();
+        BitSet bitfield = convertByteBufferToBitfieldBitSet(bitfieldBuffer);
+        assertEquals(3, bitfield.cardinality());
+        assertEquals(true, bitfield.get(00));
+        assertEquals(true, bitfield.get(700));
+        assertEquals(true, bitfield.get(743));
+    }
+
+    @Test
+    public void testCraftBitfieldMessageEmpty()  {
+        // See https://wiki.theory.org/BitTorrentSpecification#bitfield
+
+        // Create message with 744 (= 93 * 8) pieces
+        BitSet availablePieces = new BitSet();
+        PeerMessage.BitfieldMessage msg = PeerMessage.BitfieldMessage.craft(availablePieces, 744);
+
+        // Check bitfield
+        assertEquals(0, msg.getBitfield().cardinality());
+
+        // Check raw data - bitfield: <len=0001+X><id=5><bitfield>
+        ByteBuffer buffer = msg.getData();
+
+        // total size
+        assertEquals(4 + 1 + 93, buffer.remaining());
+
+        // len
+        assertEquals(0, buffer.get(0));
+        assertEquals(0, buffer.get(1));
+        assertEquals(0, buffer.get(2));
+        assertEquals(1 + 93, (int)buffer.get(3));
+
+        // id
+        assertEquals(5, buffer.get(4));
+
+        // bitfield
+        buffer.position(5);
+        ByteBuffer bitfieldBuffer = buffer.slice();
+        BitSet bitfield = convertByteBufferToBitfieldBitSet(bitfieldBuffer);
+        assertEquals(0, bitfield.cardinality());
+    }
+
+    @Test
+    public void testCreateBitfieldMessageWithSparseBits()  {
+        // See https://wiki.theory.org/BitTorrentSpecification#bitfield
+
+        // Create message with 745 (= 93 * 8 + 1) pieces
+        BitSet availablePieces = new BitSet();
+        availablePieces.set(10);
+        availablePieces.set(700);
+        availablePieces.set(744);
+        availablePieces.set(745); // out of range - should be ignored
+        PeerMessage.BitfieldMessage msg = PeerMessage.BitfieldMessage.craft(availablePieces, 745);
+
+        // Check bitfield
+        assertEquals(3, msg.getBitfield().cardinality());
+        assertEquals(true, msg.getBitfield().get(10));
+        assertEquals(true, msg.getBitfield().get(700));
+        assertEquals(true, msg.getBitfield().get(744));
+
+        // Check raw data - bitfield: <len=0001+X><id=5><bitfield>
+        ByteBuffer buffer = msg.getData();
+
+        // total size
+        assertEquals(4 + 1 + 94, buffer.remaining());
+
+        // len
+        assertEquals(0, buffer.get(0));
+        assertEquals(0, buffer.get(1));
+        assertEquals(0, buffer.get(2));
+        assertEquals(1 + 94, (int)buffer.get(3));
+
+        // id
+        assertEquals(5, buffer.get(4));
+
+        // bitfield with 7 spare bits
+        buffer.position(5);
+        ByteBuffer bitfieldBuffer = buffer.slice();
+        BitSet bitfield = convertByteBufferToBitfieldBitSet(bitfieldBuffer);
+        assertEquals(3, bitfield.cardinality());
+        assertEquals(true, bitfield.get(10));
+        assertEquals(true, bitfield.get(700));
+        assertEquals(true, bitfield.get(744));
+    }
+
+    private BitSet convertByteBufferToBitfieldBitSet(ByteBuffer buffer) {
+        BitSet bitfield = new BitSet();
+        for (int i=0; i < buffer.remaining()*8; i++) {
+            if ((buffer.get(i/8) & (1 << (7 -(i % 8)))) > 0) {
+                bitfield.set(i);
+            }
+        }
+        return bitfield;
+    }
+
+}


### PR DESCRIPTION
Bitfield payload was truncated to the highest bit that was set. As a
consequence clients dropped the connection.

This is one of two changes required to resolve issues 91: download
resume not working
https://github.com/mpetazzoni/ttorrent/issues/91