### PR TITLE
Fix byteArrayToHexString and add tests

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/ConnectionHandler.java
+++ b/core/src/main/java/com/turn/ttorrent/client/ConnectionHandler.java
@@ -17,6 +17,7 @@ package com.turn.ttorrent.client;
 
 import com.turn.ttorrent.common.Torrent;
 import com.turn.ttorrent.client.peer.SharingPeer;
+import com.turn.ttorrent.common.Utils;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -392,15 +393,15 @@ public class ConnectionHandler implements Runnable {
 		Handshake hs = Handshake.parse(data);
 		if (!Arrays.equals(hs.getInfoHash(), this.torrent.getInfoHash())) {
 			throw new ParseException("Handshake for unknow torrent " +
-					Torrent.byteArrayToHexString(hs.getInfoHash()) +
+					Utils.bytesToHex(hs.getInfoHash()) +
 					" from " + this.socketRepr(channel) + ".", pstrlen + 9);
 		}
 
 		if (peerId != null && !Arrays.equals(hs.getPeerId(), peerId)) {
 			throw new ParseException("Announced peer ID " +
-					Torrent.byteArrayToHexString(hs.getPeerId()) +
+					Utils.bytesToHex(hs.getPeerId()) +
 					" did not match expected peer ID " +
-					Torrent.byteArrayToHexString(peerId) + ".", pstrlen + 29);
+					Utils.bytesToHex(peerId) + ".", pstrlen + 29);
 		}
 
 		return hs;
@@ -501,7 +502,7 @@ public class ConnectionHandler implements Runnable {
 						 ? this.peer.getPeerId().array()
 						 : null));
 				logger.info("Handshaked with {}, peer ID is {}.",
-					this.peer, Torrent.byteArrayToHexString(hs.getPeerId()));
+					this.peer, Utils.bytesToHex(hs.getPeerId()));
 
 				// Go to non-blocking mode for peer interaction
 				channel.configureBlocking(false);

--- a/core/src/main/java/com/turn/ttorrent/common/Peer.java
+++ b/core/src/main/java/com/turn/ttorrent/common/Peer.java
@@ -107,7 +107,7 @@ public class Peer {
 	public void setPeerId(ByteBuffer peerId) {
 		if (peerId != null) {
 			this.peerId = peerId;
-			this.hexPeerId = Torrent.byteArrayToHexString(peerId.array());
+			this.hexPeerId = Utils.bytesToHex(peerId.array());
 		} else {
 			this.peerId = null;
 			this.hexPeerId = null;

--- a/core/src/main/java/com/turn/ttorrent/common/Torrent.java
+++ b/core/src/main/java/com/turn/ttorrent/common/Torrent.java
@@ -144,7 +144,7 @@ public class Torrent {
 		BEncoder.bencode(this.decoded_info, baos);
 		this.encoded_info = baos.toByteArray();
 		this.info_hash = Torrent.hash(this.encoded_info);
-		this.hex_info_hash = Torrent.byteArrayToHexString(this.info_hash);
+		this.hex_info_hash = Utils.bytesToHex(this.info_hash);
 
 		/**
 		 * Parses the announce information from the decoded meta-info
@@ -413,16 +413,6 @@ public class Torrent {
 	}
 
 	/**
-	 * Convert a byte string to a string containing an hexadecimal
-	 * representation of the original data.
-	 *
-	 * @param bytes The byte array to convert.
-	 */
-	public static String byteArrayToHexString(byte[] bytes) {
-		return new BigInteger(1, bytes).toString(16); 
-	}
-
-	/**
 	 * Return an hexadecimal representation of the bytes contained in the
 	 * given string, following the default, expected byte encoding.
 	 *
@@ -431,7 +421,7 @@ public class Torrent {
 	public static String toHexString(String input) {
 		try {
 			byte[] bytes = input.getBytes(Torrent.BYTE_ENCODING);
-			return Torrent.byteArrayToHexString(bytes);
+			return Utils.bytesToHex(bytes);
 		} catch (UnsupportedEncodingException uee) {
 			return null;
 		}

--- a/core/src/main/java/com/turn/ttorrent/common/Utils.java
+++ b/core/src/main/java/com/turn/ttorrent/common/Utils.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.turn.ttorrent.common;
+
+public class Utils {
+
+    private final static char[] HEX_SYMBOLS = "0123456789ABCDEF".toCharArray();
+
+    private Utils() {
+    }
+
+    /**
+     * Convert a byte string to a string containing the hexadecimal
+     * representation of the original data.
+     *
+     * @param bytes The byte array to convert.
+     * @see <a href="http://stackoverflow.com/questions/332079">http://stackoverflow.com/questions/332079/a>
+     */
+    public static String bytesToHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = HEX_SYMBOLS[v >>> 4];
+            hexChars[j * 2 + 1] = HEX_SYMBOLS[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+
+}

--- a/core/src/main/java/com/turn/ttorrent/common/protocol/http/HTTPAnnounceRequestMessage.java
+++ b/core/src/main/java/com/turn/ttorrent/common/protocol/http/HTTPAnnounceRequestMessage.java
@@ -21,6 +21,7 @@ import com.turn.ttorrent.bcodec.BEncoder;
 import com.turn.ttorrent.bcodec.InvalidBEncodingException;
 import com.turn.ttorrent.common.Peer;
 import com.turn.ttorrent.common.Torrent;
+import com.turn.ttorrent.common.Utils;
 import com.turn.ttorrent.common.protocol.TrackerMessage.AnnounceRequestMessage;
 
 import java.io.IOException;
@@ -81,7 +82,7 @@ public class HTTPAnnounceRequestMessage extends HTTPTrackerMessage
 
 	@Override
 	public String getHexInfoHash() {
-		return Torrent.byteArrayToHexString(this.infoHash);
+		return Utils.bytesToHex(this.infoHash);
 	}
 
 	@Override

--- a/core/src/main/java/com/turn/ttorrent/common/protocol/udp/UDPAnnounceRequestMessage.java
+++ b/core/src/main/java/com/turn/ttorrent/common/protocol/udp/UDPAnnounceRequestMessage.java
@@ -16,6 +16,7 @@
 package com.turn.ttorrent.common.protocol.udp;
 
 import com.turn.ttorrent.common.Torrent;
+import com.turn.ttorrent.common.Utils;
 import com.turn.ttorrent.common.protocol.TrackerMessage;
 
 import java.net.InetAddress;
@@ -89,7 +90,7 @@ public class UDPAnnounceRequestMessage
 
 	@Override
 	public String getHexInfoHash() {
-		return Torrent.byteArrayToHexString(this.infoHash);
+		return Utils.bytesToHex(this.infoHash);
 	}
 
 	@Override
@@ -99,7 +100,7 @@ public class UDPAnnounceRequestMessage
 
 	@Override
 	public String getHexPeerId() {
-		return Torrent.byteArrayToHexString(this.peerId);
+		return Utils.bytesToHex(this.peerId);
 	}
 
 	@Override

--- a/core/src/test/java/com/turn/ttorrent/common/UtilsTest.java
+++ b/core/src/test/java/com/turn/ttorrent/common/UtilsTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright (C) 2016 Philipp Henkel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+ package com.turn.ttorrent.common;
+
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+
+public class UtilsTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testBytesToHexWithNull() {
+        Utils.bytesToHex(null);
+    }
+
+    @Test
+    public void testBytesToHexWithEmptyByteArray() {
+        assertEquals("", Utils.bytesToHex(new byte[0]));
+    }
+
+    @Test
+    public void testBytesToHexWithSingleByte() {
+        assertEquals("BC", Utils.bytesToHex(new byte[]{
+                (byte) 0xBC
+        }));
+    }
+
+    @Test
+    public void testBytesToHexWithZeroByte() {
+        assertEquals("00", Utils.bytesToHex(new byte[1]));
+    }
+
+    @Test
+    public void testBytesToHexWithLeadingZero() {
+        assertEquals("0053FF", Utils.bytesToHex(new byte[]{
+                (byte) 0x00, (byte) 0x53, (byte) 0xFF
+        }));
+    }
+
+    @Test
+    public void testBytesToHexTrailingZero() {
+        assertEquals("AA004500", Utils.bytesToHex(new byte[]{
+                (byte) 0xAA, (byte) 0x00, (byte) 0x45, (byte) 0x00
+        }));
+    }
+
+    @Test
+    public void testBytesToHexAllSymbols() {
+        assertEquals("0123456789ABCDEF", Utils.bytesToHex(new byte[]{
+                (byte) 0x01, (byte) 0x23, (byte) 0x45, (byte) 0x67,
+                (byte) 0x89, (byte) 0xAB, (byte) 0xCD, (byte) 0xEF
+        }));
+    }
+
+}


### PR DESCRIPTION
The old implementation of byteArrayToHexString drops the byte array’s
leading zeros.