### PR TITLE
Used thread local buffers to tame GC pressure caused by piece validation

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
+++ b/core/src/main/java/com/turn/ttorrent/client/peer/PeerExchange.java
@@ -15,6 +15,7 @@
  */
 package com.turn.ttorrent.client.peer;
 
+import com.turn.ttorrent.client.Piece;
 import com.turn.ttorrent.client.SharedTorrent;
 import com.turn.ttorrent.common.protocol.PeerMessage;
 import com.turn.ttorrent.common.protocol.PeerMessage.Type;
@@ -133,7 +134,7 @@ class PeerExchange {
 		}
 	}
 
-	
+
 	/**
 	 * Register a new message listener to receive messages.
 	 *
@@ -181,7 +182,7 @@ class PeerExchange {
 		this.in.start();
 		this.out.start();
 	}
-	
+
 	/**
 	 * Stop the peer exchange.
 	 *
@@ -209,13 +210,13 @@ class PeerExchange {
 	/**
 	 * Abstract Thread subclass that allows conditional rate limiting
 	 * for <code>PIECE</code> messages.
-	 * 
+	 *
 	 * <p>
 	 * To impose rate limits, we only want to throttle when processing PIECE
 	 * messages. All other peer messages should be exchanged as quickly as
 	 * possible.
 	 * </p>
-	 * 
+	 *
 	 * @author ptgoetz
 	 */
 	private abstract class RateLimitThread extends Thread {
@@ -226,19 +227,19 @@ class PeerExchange {
 		/**
 		 * Dynamically determines an amount of time to sleep, based on the
 		 * average read/write throughput.
-		 * 
+		 *
 		 * <p>
 		 * The algorithm is functional, but could certainly be improved upon.
 		 * One obvious drawback is that with large changes in
 		 * <code>maxRate</code>, it will take a while for the sleep time to
 		 * adjust and the throttled rate to "smooth out."
 		 * </p>
-		 * 
+		 *
 		 * <p>
 		 * Ideally, it would calculate the optimal sleep time necessary to hit
 		 * a desired throughput rather than continuously adjust toward a goal.
 		 * </p>
-		 * 
+		 *
 		 * @param maxRate the target rate in kB/second.
 		 * @param messageSize the size, in bytes, of the last message read/written.
 		 * @param message the last <code>PeerMessage</code> read/written.
@@ -276,7 +277,7 @@ class PeerExchange {
 	 * parsed and passed to the peer's <code>handleMessage()</code> method that
 	 * will act based on the message type.
 	 * </p>
-	 * 
+	 *
 	 * @author mpetazzoni
 	 */
 	private class IncomingThread extends RateLimitThread {
@@ -350,14 +351,14 @@ class PeerExchange {
 					}
 
 					buffer.rewind();
-					
+
 					if (stop) {
 						// The buffer may contain the type from the last message
 						// if we were stopped before reading the payload and cause
 						// BufferUnderflowException in parsing.
 						break;
 					}
-					
+
 					try {
 						PeerMessage message = PeerMessage.parse(buffer, torrent);
 						logger.trace("Received {} from {}", message, peer);
@@ -383,6 +384,7 @@ class PeerExchange {
 				} catch (IOException ioe) {
 					this.handleIOE(ioe);
 				}
+				Piece.clearValidationBuffers();
 			}
 		}
 	}

--- a/core/src/main/java/com/turn/ttorrent/common/Torrent.java
+++ b/core/src/main/java/com/turn/ttorrent/common/Torrent.java
@@ -412,6 +412,14 @@ public class Torrent {
 		return crypt.digest();
 	}
 
+	public static byte[] hash(byte[] data, int offset, int length) throws NoSuchAlgorithmException {
+		MessageDigest crypt;
+		crypt = MessageDigest.getInstance("SHA-1");
+		crypt.reset();
+		crypt.update(data, offset, length);
+		return crypt.digest();
+	}
+
 	/**
 	 * Return an hexadecimal representation of the bytes contained in the
 	 * given string, following the default, expected byte encoding.
@@ -506,7 +514,7 @@ public class Torrent {
 	 */
 	public static Torrent create(File source, URI announce, String createdBy)
 		throws InterruptedException, IOException, NoSuchAlgorithmException {
-		return Torrent.create(source, null, DEFAULT_PIECE_LENGTH, 
+		return Torrent.create(source, null, DEFAULT_PIECE_LENGTH,
 				announce, null, createdBy);
 	}
 
@@ -529,7 +537,7 @@ public class Torrent {
 	 */
 	public static Torrent create(File parent, List<File> files, URI announce,
 		String createdBy) throws InterruptedException, IOException, NoSuchAlgorithmException {
-		return Torrent.create(parent, files, DEFAULT_PIECE_LENGTH, 
+		return Torrent.create(parent, files, DEFAULT_PIECE_LENGTH,
 				announce, null, createdBy);
 	}
 
@@ -543,17 +551,17 @@ public class Torrent {
 	 * </p>
 	 *
 	 * @param source The file to use in the torrent.
-	 * @param announceList The announce URIs organized as tiers that will 
+	 * @param announceList The announce URIs organized as tiers that will
 	 * be used for this torrent
 	 * @param createdBy The creator's name, or any string identifying the
 	 * torrent's creator.
 	 */
 	public static Torrent create(File source, int pieceLength, List<List<URI>> announceList,
 			String createdBy) throws InterruptedException, IOException, NoSuchAlgorithmException {
-		return Torrent.create(source, null, pieceLength, 
+		return Torrent.create(source, null, pieceLength,
 				null, announceList, createdBy);
 	}
-	
+
 	/**
 	 * Create a {@link Torrent} object for a set of files.
 	 *
@@ -567,7 +575,7 @@ public class Torrent {
 	 * @param source The parent directory or location of the torrent files,
 	 * also used as the torrent's name.
 	 * @param files The files to add into this torrent.
-	 * @param announceList The announce URIs organized as tiers that will 
+	 * @param announceList The announce URIs organized as tiers that will
 	 * be used for this torrent
 	 * @param createdBy The creator's name, or any string identifying the
 	 * torrent's creator.
@@ -575,10 +583,10 @@ public class Torrent {
 	public static Torrent create(File source, List<File> files, int pieceLength,
 			List<List<URI>> announceList, String createdBy)
 			throws InterruptedException, IOException, NoSuchAlgorithmException {
-		return Torrent.create(source, files, pieceLength, 
+		return Torrent.create(source, files, pieceLength,
 				null, announceList, createdBy);
 	}
-	
+
 	/**
 	 * Helper method to create a {@link Torrent} object for a set of files.
 	 *
@@ -593,7 +601,7 @@ public class Torrent {
 	 * also used as the torrent's name.
 	 * @param files The files to add into this torrent.
 	 * @param announce The announce URI that will be used for this torrent.
-	 * @param announceList The announce URIs organized as tiers that will 
+	 * @param announceList The announce URIs organized as tiers that will
 	 * be used for this torrent
 	 * @param createdBy The creator's name, or any string identifying the
 	 * torrent's creator.
@@ -625,7 +633,7 @@ public class Torrent {
 			}
 			torrent.put("announce-list", new BEValue(tiers));
 		}
-		
+
 		torrent.put("creation date", new BEValue(new Date().getTime() / 1000));
 		torrent.put("created by", new BEValue(createdBy));
 


### PR DESCRIPTION
Piece validation allocates 2x memory for each piece received, which could cause frequent young gen GC's and premature old gen promotions. This memory pressure can be alleviated by using pre-allocated thread local buffers as the scratch pad for the validation. A byte array and a ByteBuffer are allocated for each PeerExchange.IncomingThread and released when the thread exits.

Before:
![screenshot-heliosshell-0 1 28-snapshot - yourkit java profiler 2014 build 14114 - 64-bit-1](https://cloud.githubusercontent.com/assets/5687598/18647065/2564f920-7e69-11e6-9c36-052539eae3aa.png)

After:
![screenshot-heliosshell-0 1 28-snapshot - yourkit java profiler 2014 build 14114 - 64-bit-2](https://cloud.githubusercontent.com/assets/5687598/18646910/87dd3e9c-7e68-11e6-9a45-50502692707c.png)


