### PR TITLE
Make it "clearer" that the target file might "not be there"

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ client.download();
 client.waitForCompletion();
 
 // At any time you can call client.stop() to interrupt the download.
+
+// If you plan on using the downloaded file(s) right away uncomment the line below
+//client.getTorrent().finish();
 ```
 
 #### Tracker code


### PR DESCRIPTION
The torrent finished state happens after the download completion, but eventually, if the target file has to be used right away you have to "finish" it manually