### PR TITLE
Closing channel unable to be used but already given fd by OS

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/ConnectionHandler.java
+++ b/core/src/main/java/com/turn/ttorrent/client/ConnectionHandler.java
@@ -134,6 +134,8 @@ public class ConnectionHandler implements Runnable {
 			} catch (IOException ioe) {
 				// Ignore, try next port
 				logger.warn("Could not bind to {}, trying next port...", tryAddress);
+
+				this.channel.close();
 			}
 		}
 


### PR DESCRIPTION
This bug can be seen if you "open" more than 1 client locally, since the trying for bind() always goes from PORT_RANGE_START to PORT_RANGE_END the number of leaked file descriptors (socket, TCP) can be determined by the summation of (i - 1) for i in N:

for (int i = 1; i <= N; i++) { sum += i - 1; }

To get a high throughput I'm creating a lot of seeder clients, so I exhausted the number of fds rather quickly, heh.
