### PR TITLE
support third-party TorrentByteStorage implementations

### DIFF
--- a/core/src/main/java/com/turn/ttorrent/client/storage/ChildStorageDecorator.java
+++ b/core/src/main/java/com/turn/ttorrent/client/storage/ChildStorageDecorator.java
@@ -1,0 +1,56 @@
+package com.turn.ttorrent.client.storage;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * @author <a href="mailto:xianguang.zhou@outlook.com">Xianguang Zhou</a>
+ */
+public class ChildStorageDecorator implements TorrentByteStorage {
+
+	private final TorrentByteStorage storage;
+	private final long offset;
+	
+	public ChildStorageDecorator(TorrentByteStorage storage) {
+		this(storage, 0);
+	}
+
+	public ChildStorageDecorator(TorrentByteStorage storage, long offset) {
+		this.storage = storage;
+		this.offset = offset;
+	}
+
+	public long offset() {
+		return this.offset;
+	}
+
+	@Override
+	public long size() {
+		return this.storage.size();
+	}
+
+	@Override
+	public int read(ByteBuffer buffer, long offset) throws IOException {
+		return this.storage.read(buffer, offset);
+	}
+
+	@Override
+	public int write(ByteBuffer block, long offset) throws IOException {
+		return this.storage.write(block, offset);
+	}
+
+	@Override
+	public void close() throws IOException {
+		this.storage.close();
+	}
+
+	@Override
+	public void finish() throws IOException {
+		this.storage.finish();
+	}
+
+	@Override
+	public boolean isFinished() {
+		return this.storage.isFinished();
+	}
+}

--- a/core/src/main/java/com/turn/ttorrent/client/storage/FileStorage.java
+++ b/core/src/main/java/com/turn/ttorrent/client/storage/FileStorage.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
  * </p>
  *
  * @author mpetazzoni
+ * @author <a href="mailto:xianguang.zhou@outlook.com">Xianguang Zhou</a>
  */
 public class FileStorage implements TorrentByteStorage {
 
@@ -44,21 +45,15 @@ public class FileStorage implements TorrentByteStorage {
 
 	private final File target;
 	private final File partial;
-	private final long offset;
 	private final long size;
 
 	private RandomAccessFile raf;
 	private FileChannel channel;
 	private File current;
 
-	public FileStorage(File file, long size) throws IOException {
-		this(file, 0, size);
-	}
-
-	public FileStorage(File file, long offset, long size)
+	public FileStorage(File file, long size)
 		throws IOException {
 		this.target = file;
-		this.offset = offset;
 		this.size = size;
 
 		this.partial = new File(this.target.getAbsolutePath() +
@@ -88,16 +83,11 @@ public class FileStorage implements TorrentByteStorage {
 
 		this.channel = raf.getChannel();
 		logger.info("Initialized byte storage file at {} " +
-			"({}+{} byte(s)).",
+			"({} byte(s)).",
 			new Object[] {
 				this.current.getAbsolutePath(),
-				this.offset,
 				this.size,
 			});
-	}
-
-	protected long offset() {
-		return this.offset;
 	}
 
 	@Override

--- a/core/src/main/java/com/turn/ttorrent/client/storage/FileStorageFactory.java
+++ b/core/src/main/java/com/turn/ttorrent/client/storage/FileStorageFactory.java
@@ -1,0 +1,45 @@
+package com.turn.ttorrent.client.storage;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.turn.ttorrent.common.Torrent.TorrentFile;
+
+/**
+ * @author <a href="mailto:xianguang.zhou@outlook.com">Xianguang Zhou</a>
+ */
+public class FileStorageFactory implements StorageFactory {
+
+	private final File parent;
+	private final String parentPath;
+
+	/**
+	 * @param parent
+	 *            The parent directory or location the torrent files.
+	 * @throws IOException
+	 *             If an I/O error occurs, which is possible because the
+	 *             construction of the canonical pathname may require filesystem
+	 *             queries
+	 */
+	public FileStorageFactory(File parent) throws IOException {
+		if (parent == null || !parent.isDirectory()) {
+			throw new IllegalArgumentException("Invalid parent directory!");
+		}
+		
+		this.parent = parent;
+		this.parentPath = parent.getCanonicalPath();
+	}
+
+	@Override
+	public TorrentByteStorage create(TorrentFile torrentFile) throws IOException {
+		File actual = new File(parent, torrentFile.file.getPath());
+
+		if (!actual.getCanonicalPath().startsWith(parentPath)) {
+			throw new SecurityException("Torrent file path attempted to break directory jail!");
+		}
+
+		actual.getParentFile().mkdirs();
+		return new FileStorage(actual, torrentFile.size);
+	}
+
+}

--- a/core/src/main/java/com/turn/ttorrent/client/storage/StorageFactory.java
+++ b/core/src/main/java/com/turn/ttorrent/client/storage/StorageFactory.java
@@ -1,0 +1,12 @@
+package com.turn.ttorrent.client.storage;
+
+import java.io.IOException;
+
+import com.turn.ttorrent.common.Torrent;
+
+/**
+ * @author <a href="mailto:xianguang.zhou@outlook.com">Xianguang Zhou</a>
+ */
+public interface StorageFactory {
+	TorrentByteStorage create(Torrent.TorrentFile torrentFile) throws IOException;
+}

--- a/core/src/test/java/com/turn/ttorrent/client/storage/CompositeStorageTest.java
+++ b/core/src/test/java/com/turn/ttorrent/client/storage/CompositeStorageTest.java
@@ -15,8 +15,9 @@ import static org.testng.Assert.assertTrue;
 /**
  * User: loyd
  * Date: 11/24/13
+ * @author <a href="mailto:xianguang.zhou@outlook.com">Xianguang Zhou</a>
  */
-public class FileCollectionStorageTest {
+public class CompositeStorageTest {
     @Test
     public void testSelect() throws Exception {
         final File file1 = File.createTempFile("testng", "fcst");
@@ -24,10 +25,10 @@ public class FileCollectionStorageTest {
         final File file2 = File.createTempFile("testng", "fcst");
         file2.deleteOnExit();
 
-        final List<FileStorage> files = new ArrayList<FileStorage>();
-        files.add(new FileStorage(file1, 0, 2));
-        files.add(new FileStorage(file2, 2, 2));
-        final FileCollectionStorage storage = new FileCollectionStorage(files, 4);
+        final List<ChildStorageDecorator> childStorageDecorators = new ArrayList<ChildStorageDecorator>();
+        childStorageDecorators.add(new ChildStorageDecorator(new FileStorage(file1, 2), 0));
+        childStorageDecorators.add(new ChildStorageDecorator(new FileStorage(file2, 2), 2));
+        final CompositeStorage storage = new CompositeStorage(childStorageDecorators, 4);
         // since all of these files already exist, we are considered finished
         assertTrue(storage.isFinished());
 
@@ -49,13 +50,18 @@ public class FileCollectionStorageTest {
         check(new byte[]{102,11}, file2);
     }
 
-    private void write(byte[] bytes, int offset, FileCollectionStorage storage) throws IOException {
+    private void write(byte[] bytes, int offset, CompositeStorage storage) throws IOException {
         storage.write(ByteBuffer.wrap(bytes), offset);
         storage.finish();
     }
     private void check(byte[] bytes, File f) throws IOException {
-        final byte[] temp = new byte[bytes.length];
-        assertEquals(new FileInputStream(f).read(temp), temp.length);
-        assertEquals(temp, bytes);
+		final byte[] temp = new byte[bytes.length];
+		FileInputStream fileInputStream = new FileInputStream(f);
+		try {
+			assertEquals(fileInputStream.read(temp), temp.length);
+			assertEquals(temp, bytes);
+		} finally {
+			fileInputStream.close();
+		}
     }
 }

--- a/core/src/test/java/com/turn/ttorrent/common/protocol/PeerMessageTest.java
+++ b/core/src/test/java/com/turn/ttorrent/common/protocol/PeerMessageTest.java
@@ -1,4 +1,4 @@
-package com.turn.ttorrent.common;
+package com.turn.ttorrent.common.protocol;
 
 import com.turn.ttorrent.common.protocol.PeerMessage;
 


### PR DESCRIPTION
Support other TorrentByteStorages which are implemented by third-party. Third-party TorrentByteStorage implementations are used to download files to some places, such as memory, database and so on.