### PR TITLE
Speed up downloading: do not calculate hash of blank pieces

### DIFF
--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/FileCollectionStorage.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/FileCollectionStorage.java
@@ -137,6 +137,26 @@ public class FileCollectionStorage implements TorrentByteStorage {
   }
 
   @Override
+  public boolean isBlank(long position, long size) {
+    for (FileOffset fo : this.select(position, size)) {
+      if (!fo.file.isBlank(fo.offset, fo.length)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean isBlank() {
+    for (FileStorage file : this.files) {
+      if (!file.isBlank()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
   public synchronized void close() throws IOException {
     for (FileStorage file : this.files) {
       file.close();

--- a/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/TorrentByteStorage.java
+++ b/ttorrent-client/src/main/java/com/turn/ttorrent/client/storage/TorrentByteStorage.java
@@ -93,6 +93,19 @@ public interface TorrentByteStorage extends Closeable {
   boolean isFinished();
 
   /**
+   * @param position Position in the underlying byte storage to write the block at.
+   * @param size Size of region to check.
+   * @return true if the region starting with positions only contains zeros
+   */
+  boolean isBlank(long position, long size);
+
+  /**
+   *
+   * @return true if the enter storage only contains zeros
+   */
+  boolean isBlank();
+
+  /**
    * Delete byte storage information
    */
   void delete() throws IOException;

--- a/ttorrent-client/src/test/java/com/turn/ttorrent/client/ByteArrayStorage.java
+++ b/ttorrent-client/src/test/java/com/turn/ttorrent/client/ByteArrayStorage.java
@@ -9,9 +9,11 @@ public class ByteArrayStorage implements TorrentByteStorage {
 
   private final byte[] array;
   private boolean finished = false;
+  private boolean isBlank;
 
   public ByteArrayStorage(int maxSize) {
     array = new byte[maxSize];
+    isBlank = true;
   }
 
   @Override
@@ -41,6 +43,7 @@ public class ByteArrayStorage implements TorrentByteStorage {
     byte[] toWrite = new byte[bytesCount];
     block.get(toWrite);
     System.arraycopy(toWrite, 0, array, pos, toWrite.length);
+    isBlank = false;
     return bytesCount;
   }
 
@@ -52,6 +55,16 @@ public class ByteArrayStorage implements TorrentByteStorage {
   @Override
   public boolean isFinished() {
     return finished;
+  }
+
+  @Override
+  public boolean isBlank(long position, long size) {
+    return isBlank;
+  }
+
+  @Override
+  public boolean isBlank() {
+    return isBlank;
   }
 
   @Override

--- a/ttorrent-client/src/test/java/com/turn/ttorrent/client/storage/FairPieceStorageFactoryTest.java
+++ b/ttorrent-client/src/test/java/com/turn/ttorrent/client/storage/FairPieceStorageFactoryTest.java
@@ -71,6 +71,16 @@ public class FairPieceStorageFactoryTest {
       }
 
       @Override
+      public boolean isBlank(long position, long size) {
+        return false;
+      }
+
+      @Override
+      public boolean isBlank() {
+        return false;
+      }
+
+      @Override
       public void delete() {
         throw notImplemented();
       }


### PR DESCRIPTION
When downloading `FairPieceStorageFactory.createStorage` could not tell the difference between a partial download and a completely blank piece it just created. Then it would compute SHA-1 hash in both cases.

If we have a newly created blank piece we assume that the torrent does not have a blank piece and download that piece without looking at the hash. I.e. do not put it in `availablePieces`.

This should be significant speed up when downloading. I did the `CommunicationManagerTest#download_many_times` test 50 times and without the delay, i.e:
```java
    for (int i = 0; i < 50; i++) {
      downloadAndStop(torrent, 250 * 1000, createClient());
    }
```
In jProfiler I see that `java.security.MessageDigest.digest` (calculation SHA-1) before optimizations took 2,295 ms (24 %). And after it takes 1,209 ms (13 %). So I expect >10% speed improvement for downloads.